### PR TITLE
chore: update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,44 @@
-# See GitHub's documentation for more information on this file:
-# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Policy: adopt updates automatically only WITHIN the currently declared major
+# version. Security updates are exempt and may cross majors. Updates are grouped
+# into a single PR per ecosystem and opened weekly.
 version: 2
 updates:
-  # Maintain dependencies for Go modules
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - package-ecosystem: gomod
+    directories:
+      - /
+      - /tools
     schedule:
-      # Check for updates to Go modules every weekday
-      interval: "daily"
-  - package-ecosystem: "gomod"
-    directory: "/tools"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      all:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    # TODO: Dependabot only updates hashicorp GHAs in the template repository, the following lines can be removed for consumers of this template
-    allow:
-      - dependency-name: "hashicorp/*"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      all:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major

--- a/.github/workflows/pr-notify-external-author.yml
+++ b/.github/workflows/pr-notify-external-author.yml
@@ -1,0 +1,13 @@
+name: 🔍 Notify external PR author
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  notify:
+    uses: tv4/actions/.github/workflows/notify-external-pr-author.yml@main
+    with:
+      team: core-engineering-platform
+      channel: C091B99UXJA #engineering-platform-internal
+    secrets: inherit


### PR DESCRIPTION
## Dependency bump method + external PR author notification

This branch now **also** adds `.github/workflows/pr-notify-external-author.yml` (copied verbatim from the `backoffice` exemplar). When an external contributor opens a pull request, it notifies the **core-engineering-platform** team in Slack (`#engineering-platform-internal`) via the shared [`tv4/actions`](https://github.com/TV4/actions) `notify-external-pr-author` reusable workflow.

The pre-existing changes on this branch (Dependabot configuration / related CEP-1915 work) are retained.

Part of CEP-1915.
